### PR TITLE
Allow +2 more missing N-term residues

### DIFF
--- a/ImmuneBuilder/sequence_checks.py
+++ b/ImmuneBuilder/sequence_checks.py
@@ -24,7 +24,7 @@ def number_single_sequence(sequence, chain, scheme="imgt", allowed_species=['hum
     numbers = [x[0][0] for x in output]
 
     # Check for missing residues assuming imgt numbering
-    assert (max(numbers) > 120) and (min(numbers) < 8), f"Sequence missing too many residues to model correctly. Please give whole sequence:\n{sequence}"
+    assert (max(numbers) > 120) and (min(numbers) < 10), f"Sequence missing too many residues to model correctly. Please give whole sequence:\n{sequence}"
 
     # Renumber once sanity checks done
     if scheme == "raw":


### PR DESCRIPTION
Currently Elipovimab sequence is not supported because it misses 8 n-term residues in L chain:

HC: QMQLQESGPGLVKPSETLSLTCSVSGASISDSYWSWIRRSPGKGLEWIGYVHKSGDTNYNPSLKSRVHLSLDTSKNQVSLSLTGVTAADSGKYYCARTLHGRRIYGIVAFNEWFTYFYMDVWGTGTQVTVSS

LC: SDISVAPGETARISCGEKSLGSRAVQWYQHRAGQAPSLIIYNNQDRPSGIPERFSGSPDSRPGTTATLTITSVEAGDEADYYCHIWDSRVPTKWVFGGGTTLTVL

Numbered:
```
       L9 S
      L10 D
      L11 I
      L12 S
      L13 V
      ...
```

Would it be safe to allow 8 missing N-term residues - starting from at least `IMGT L9`?

Example:
```
from ImmuneBuilder import ABodyBuilder2

ABodyBuilder2().predict({
  'H': 'QMQLQESGPGLVKPSETLSLTCSVSGASISDSYWSWIRRSPGKGLEWIGYVHKSGDTNYNPSLKSRVHLSLDTSKNQVSLSLTGVTAADSGKYYCARTLHGRRIYGIVAFNEWFTYFYMDVWGTGTQVTVSS', 
  'L': 'SDISVAPGETARISCGEKSLGSRAVQWYQHRAGQAPSLIIYNNQDRPSGIPERFSGSPDSRPGTTATLTITSVEAGDEADYYCHIWDSRVPTKWVFGGGTTLTVL'
}).save('Elipovimab_predicted.pdb')
```

Superimposition of predicted structure (pink) with 4fq1 ground truth (green):

[Elipovimab_prediction.cif.zip](https://github.com/user-attachments/files/15971547/Elipovimab_prediction.cif.zip)

<img width="789" alt="image" src="https://github.com/oxpig/ImmuneBuilder/assets/2894124/f428864e-e0cf-4e4f-a006-dcc7929a816e">


