### PR TITLE
Fixed disabled logging and sys.exit statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,166 @@
+.vscode/
+notebook/
+trained_models/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/ImmuneBuilder/ABodyBuilder2.py
+++ b/ImmuneBuilder/ABodyBuilder2.py
@@ -173,7 +173,7 @@ def command_line_interface():
         antibody = ABodyBuilder2(numbering_scheme=args.numbering_scheme).predict(seqs)
     except AssertionError as e:
         print(e, flush=True)
-        sys.exit(1)
+        raise
 
     if args.verbose:
         print("Antibody modelled succesfully, starting refinement.", flush=True)

--- a/ImmuneBuilder/NanoBodyBuilder2.py
+++ b/ImmuneBuilder/NanoBodyBuilder2.py
@@ -178,7 +178,7 @@ def command_line_interface():
         antibody = NanoBodyBuilder2(numbering_scheme=args.numbering_scheme).predict(seqs)
     except AssertionError as e:
         print(e, flush=True)
-        sys.exit(1)
+        raise
 
     if args.verbose:
         print("Nanobody modelled succesfully, starting refinement.", flush=True)

--- a/ImmuneBuilder/TCRBuilder2.py
+++ b/ImmuneBuilder/TCRBuilder2.py
@@ -200,7 +200,7 @@ def command_line_interface():
         tcr = TCRBuilder2(use_TCRBuilder2_PLUS_weights=not args.original_weights).predict(seqs)
     except AssertionError as e:
         print(e, flush=True)
-        sys.exit(1)
+        raise
     
     if args.verbose:
         print("TCR modelled succesfully, starting refinement.", flush=True)

--- a/ImmuneBuilder/refine.py
+++ b/ImmuneBuilder/refine.py
@@ -4,7 +4,7 @@ import numpy as np
 from openmm import app, LangevinIntegrator, CustomExternalForce, CustomTorsionForce, OpenMMException, Platform, unit
 from scipy import spatial
 import logging
-logging.disable()
+# logging.disable()
 
 ENERGY = unit.kilocalories_per_mole
 LENGTH = unit.angstroms

--- a/scripts/predict-nanobody.py
+++ b/scripts/predict-nanobody.py
@@ -1,0 +1,52 @@
+import click
+import torch
+import tqdm
+from Bio import SeqIO
+
+from ImmuneBuilder import NanoBodyBuilder2
+from ImmuneBuilder.util import get_encoding
+from ImmuneBuilder.sequence_checks import number_sequences
+
+
+def _number_sequence(sequence_dict):
+    return number_sequences(sequence_dict, allowed_species=None, scheme = 'imgt')
+
+def _get_sequence_from_numbered(numbered_sequence_dict):
+    return {chain: "".join([x[1] for x in numbered_sequence_dict[chain]]) for chain in numbered_sequence_dict}
+
+def _encode(sequence_dict):
+    return torch.tensor(get_encoding(sequence_dict, 'H'), dtype=torch.get_default_dtype())
+
+@click.command()
+@click.argument('fasta', type=str, required=True)
+@click.option('-d', '--device', help="Device to run on", type=str, default="cpu")
+@click.option('-o', '--output', help="Output pickle file", type=str, required=True)
+def main(fasta, device, output):
+    models = NanoBodyBuilder2().models.values()
+    for model in models:
+        model.to(device)
+        model.eval()
+
+    results = dict()
+    for record in tqdm.tqdm(SeqIO.parse(fasta, "fasta")):
+        sequence_dict_numbered = _number_sequence({'H': str(record.seq)})
+        sequence_dict = _get_sequence_from_numbered(sequence_dict_numbered)
+
+        node_features = _encode(sequence_dict)
+        sequence = sequence_dict['H']
+
+        # need to add dummy light chain key
+        sequence_dict_numbered['L'] = []
+
+        outputs = []
+        with torch.no_grad():
+            for model in models:
+                out = model(node_features.to(device), sequence)
+                out = (out[0].detach().cpu(), out[1].detach().cpu())
+                outputs.append(out)
+        results[record.id] = {'predictions': outputs, 'sequence_numbered': sequence_dict_numbered}
+    
+    torch.save(results, output)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/refine-nanobody.py
+++ b/scripts/refine-nanobody.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import click
+import tqdm
+import torch
+
+from ImmuneBuilder.NanoBodyBuilder2 import Nanobody
+
+@click.command()
+@click.argument('predictions_pt', type=str, required=True)
+@click.option('-o', '--output-fmt', help="Output. Use {id} for record id.", type=str, default="{id}.pdb")
+def main(predictions_pt, output_fmt):
+    predictions = torch.load(predictions_pt)
+    for record_id, result in tqdm.tqdm(predictions.items()):
+        out_fpath = Path(output_fmt.format(id=record_id))
+        out_fpath.parent.mkdir(parents=True, exist_ok=True)
+
+        nanobody = Nanobody(result['sequence_numbered'], result['predictions'])
+        nanobody.save(str(out_fpath))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- `logging.disable()` disables logging globally whenever this package is imported, interfering with user code. 
- sys.exit prevents users from handling errors gracefully, e.g. by skipping the Ab. These calls were replaced with raise statements, which allow the user to catch and deal with errors. 